### PR TITLE
Add new option `reevaluate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ changeTracker {
     tasks = ['lint','testDebugUnitTest']
     whitelist = [':app']
     blacklist = [':network',':featureA']
+    reevaluate = [':sharedTestModule']
     branch = "master"
 }
 ```
 - `tasks`: List of tasks the plugin will need to create. 
 - `whitelist` (optional): List of modules that should **always** run.
 - `blacklist` (optional): List of modules that should **never** run.
+- `reevaluate` (optional): List of modules that will trigger the task for all modules
 - `branch`: Name of the branch that should compare to the current one to extract the diff.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -29,14 +29,15 @@ changeTracker {
     tasks = ['lint','testDebugUnitTest']
     whitelist = [':app']
     blacklist = [':network',':featureA']
-    reevaluate = [':sharedTestModule']
     branch = "master"
 }
 ```
+<!--- Add this above (comment does not work): reevaluate = [':sharedTest'] --->
+
 - `tasks`: List of tasks the plugin will need to create. 
 - `whitelist` (optional): List of modules that should **always** run.
 - `blacklist` (optional): List of modules that should **never** run.
-- `reevaluate` (optional): List of modules that will trigger the task for all modules
+<!--- - `reevaluate` (optional): List of modules that will trigger the task for all modules --->
 - `branch`: Name of the branch that should compare to the current one to extract the diff.
 
 ## Usage
@@ -59,6 +60,23 @@ You can override the default branch used for the comparison when running your co
 ./gradlew testChangedModules -Pbranch=dev
 ```
 
+<!---
+## Cyclic Test Dependencies
+In modular Android projects often testing code exists, which is shared between modules. 
+In such cases, the testing code resides in a module and is used by others modules using
+`testImplementation project(path: ":sharedTest")`. 
+This could lead to cyclic dependencies if the `:sharedTest` depends on another module which uses the `:sharedTest` for tests itself.
+Let's create an example with 2 modules:
+- `:database`: A module which contains code to handle the app's database. Its test requires shared testing code and thus is configured to depend on
+the `:sharedTest` using `testImplementation(project(:sharedTest))`
+- `sharedTest`: Our module with shared test code. As it provides mocks for database testing it depends on `:database`.
+So it has a dependency on `:database` with `implementation(project(:database))`
+
+In this particular example, we created a cyclic dependency if the configuration (`testImplementation`, `androidTestImplementation`, ...) is not considered.
+Because of this, test configurations are not part of the dependency evaluation. 
+However, if you apply changes to `:sharedTest`, `:database` needs to be verified as well. 
+In this case, specify the `:sharedTest` module in the `reevaluate` list to trigger your verification tasks for all modules. 
+--->
 
 <br clear="right"/>
 

--- a/change_tracker/src/main/kotlin/com/ismaeldivita/changetracker/ChangeTrackerExtension.kt
+++ b/change_tracker/src/main/kotlin/com/ismaeldivita/changetracker/ChangeTrackerExtension.kt
@@ -7,6 +7,7 @@ open class ChangeTrackerExtension : Serializable {
     var tasks = emptySet<String>()
     var whitelist = emptySet<String>()
     var blacklist = emptySet<String>()
+    var reevaluate = emptySet<String>()
     var branch = "master"
 
 }

--- a/change_tracker/src/main/kotlin/com/ismaeldivita/changetracker/ChangedModulesTask.kt
+++ b/change_tracker/src/main/kotlin/com/ismaeldivita/changetracker/ChangedModulesTask.kt
@@ -12,6 +12,7 @@ open class ChangedModulesTask : DefaultTask() {
 
     private val whitelist by lazy { getProjectsByName(changeTrackerExtension.whitelist) }
     private val blacklist by lazy { getProjectsByName(changeTrackerExtension.blacklist) }
+    private val reevaluate by lazy { getProjectsByName(changeTrackerExtension.reevaluate) }
     private val branch by lazy { getProperty<String>("branch") ?: changeTrackerExtension.branch }
 
     override fun getGroup(): String? = CHANGED_TRACKER_GROUP_NAME
@@ -26,6 +27,7 @@ open class ChangedModulesTask : DefaultTask() {
 
         val result: MutableSet<Project> = when {
             changedProjects.contains(rootProject) -> rootProject.subprojects
+            reevaluate.any(changedProjects::contains) -> rootProject.subprojects
             changedProjects.contains(null) -> rootProject.subprojects
             else -> changedProjects
                 .filterNotNull()

--- a/change_tracker/src/main/kotlin/com/ismaeldivita/changetracker/project/ProjectDependents.kt
+++ b/change_tracker/src/main/kotlin/com/ismaeldivita/changetracker/project/ProjectDependents.kt
@@ -18,12 +18,14 @@ class ProjectDependents(rootProject: Project) {
 
     private fun Map<Project, MutableSet<Project>>.traverseDependencies() {
         forEach { subProject, _ ->
-            subProject.configurations.forEach { config ->
-                config
-                    .dependencies
-                    .filterIsInstance<ProjectDependency>()
-                    .forEach { getValue(it.dependencyProject).add(subProject) }
-            }
+            subProject.configurations
+                .filter { !it.name.toLowerCase().contains("test") }
+                .forEach { config ->
+                    config
+                        .dependencies
+                        .filterIsInstance<ProjectDependency>()
+                        .forEach { getValue(it.dependencyProject).add(subProject) }
+                }
         }
     }
 


### PR DESCRIPTION
Thank you very much for this awesome plugin. It improved our CI pipeline by far. 

This PR adds the following changes:
- Remove blacklist projects before evaluating the dependents: In our specific case, we have a module defined which only has lint rules. As this module is not a `com.android.library` or `com.android.application` it misses tasks like unit tests. This results in warnings, even when this module is added to the blacklist 
- Exclude test configuration when evaluating project dependents: This fixes #3 as you could run into cyclic dependencies because the configuration is not considered. Example: 
`databaseModule`: `testImplementation(project(:sharedTestModule))`
`sharedTestModule`: `implementation(project(:databaseModule))`
This is possible, as the `databaseModule` has only a dependency in its tests, while the `sharedTestModule` needs database functionality for testing purposes. 
- Reevaluate option: As the test depedencies are not considered for evaluation, there has to be an option to trigger all tasks in case the `sharedTestModule` has changes. 

I was unable to test these changes locally, as I am not versed enough in gradle to get this plugin to run for development purposes in our project. Hopefully, @ismaeldivita can confirm the changes work.